### PR TITLE
Add baseline agents and simple block game environment

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,36 @@
+import random
+from typing import Tuple
+from block_env import BlockGame
+
+
+class RandomAgent:
+    """Agent that selects actions uniformly at random."""
+
+    def select_action(self, env: BlockGame) -> Tuple[int, int]:
+        actions = env.valid_actions()
+        return random.choice(actions)
+
+
+class GreedyAgent:
+    """Agent that evaluates actions with simple heuristics."""
+
+    def select_action(self, env: BlockGame) -> Tuple[int, int]:
+        best_score = None
+        best_action = None
+        for action in env.valid_actions():
+            score = self._evaluate(env, action)
+            if best_score is None or score > best_score:
+                best_score = score
+                best_action = action
+        # Fallback in case no action evaluated (e.g., board full)
+        return best_action if best_action is not None else random.choice(env.valid_actions())
+
+    def _evaluate(self, env: BlockGame, action: Tuple[int, int]) -> float:
+        # Simulate placing the block
+        board_copy = [row[:] for row in env.board]
+        r, c = action
+        board_copy[r][c] = 1
+        board_copy, cleared = env._clear_lines(board_copy)
+        gaps = env._count_gaps(board_copy)
+        # Higher score for more cleared cells, lower for gaps
+        return cleared * 10 - gaps

--- a/block_env.py
+++ b/block_env.py
@@ -1,0 +1,65 @@
+from typing import List, Tuple
+
+
+class BlockGame:
+    """Simple clearing puzzle environment using plain Python lists."""
+
+    def __init__(self, size: int = 8):
+        self.size = size
+        self.board = [[0 for _ in range(size)] for _ in range(size)]
+
+    def reset(self) -> List[List[int]]:
+        for r in range(self.size):
+            for c in range(self.size):
+                self.board[r][c] = 0
+        return [row[:] for row in self.board]
+
+    # --- Helpers -----------------------------------------------------
+    def _clear_lines(self, board: List[List[int]]) -> Tuple[List[List[int]], int]:
+        cleared = 0
+        # Clear full rows
+        for r in range(self.size):
+            if all(board[r][c] == 1 for c in range(self.size)):
+                for c in range(self.size):
+                    board[r][c] = 0
+                cleared += self.size
+        # Clear full columns
+        for c in range(self.size):
+            if all(board[r][c] == 1 for r in range(self.size)):
+                for r in range(self.size):
+                    board[r][c] = 0
+                cleared += self.size
+        return board, cleared
+
+    def _count_gaps(self, board: List[List[int]]) -> int:
+        gaps = 0
+        for c in range(self.size):
+            filled_seen = False
+            for r in range(self.size):
+                if board[r][c] == 1:
+                    filled_seen = True
+                elif filled_seen:
+                    gaps += 1
+        return gaps
+
+    # --- API ---------------------------------------------------------
+    def valid_actions(self) -> List[Tuple[int, int]]:
+        actions = []
+        for r in range(self.size):
+            for c in range(self.size):
+                if self.board[r][c] == 0:
+                    actions.append((r, c))
+        return actions
+
+    def step(self, action: Tuple[int, int]) -> Tuple[List[List[int]], int, bool]:
+        r, c = action
+        if self.board[r][c] != 0:
+            raise ValueError("Invalid action: cell is already filled")
+        self.board[r][c] = 1
+        self.board, cleared = self._clear_lines(self.board)
+        done = len(self.valid_actions()) == 0
+        return [row[:] for row in self.board], int(cleared), done
+
+    def render(self) -> None:
+        for row in self.board:
+            print(" ".join(str(cell) for cell in row))

--- a/play_baselines.py
+++ b/play_baselines.py
@@ -1,0 +1,40 @@
+"""Run baseline agents against the block puzzle environment."""
+import argparse
+from agents import RandomAgent, GreedyAgent
+from block_env import BlockGame
+
+
+def run_game(agent_name: str, size: int, max_steps: int = 1000) -> None:
+    env = BlockGame(size=size)
+    env.reset()
+    if agent_name == "greedy":
+        agent = GreedyAgent()
+    else:
+        agent = RandomAgent()
+
+    total_reward = 0
+    done = False
+    steps = 0
+    while not done and steps < max_steps:
+        action = agent.select_action(env)
+        _, reward, done = env.step(action)
+        total_reward += reward
+        steps += 1
+    if not done:
+        print("Reached step limit; terminating game early.")
+
+    print(f"Agent: {agent_name}, board size: {size}")
+    env.render()
+    print(f"Final score: {total_reward}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent", choices=["random", "greedy"], default="random")
+    parser.add_argument("--size", type=int, default=8, help="board size")
+    args = parser.parse_args()
+    run_game(args.agent, args.size)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add plain Python BlockGame environment with line clearing and gap counting
- Implement RandomAgent and heuristic-based GreedyAgent
- Provide play_baselines script to run the agents

## Testing
- `python -m py_compile block_env.py agents.py play_baselines.py`
- `python play_baselines.py --agent random --size 4`
- `python play_baselines.py --agent greedy --size 4`


------
https://chatgpt.com/codex/tasks/task_e_689d1e6a7628832a9318f5346ab7e6c7