### PR TITLE
Limit reasoning demo to finite steps

### DIFF
--- a/play_reasoning.py
+++ b/play_reasoning.py
@@ -34,7 +34,15 @@ def print_board(board: List[List[int]]) -> None:
     print()
 
 
-def run_episode(size: int = 8):
+def run_episode(size: int = 8, max_steps: int = 100):
+    """Play one episode using the reasoning agent.
+
+    The original implementation would continue forever because clearing a
+    complete row or column makes new actions available again. To keep example
+    runs short and avoid the need to interrupt manually, we cap the number of
+    steps with ``max_steps``.
+    """
+
     env = BlockGame(size=size)
     agent = ReasoningGreedyAgent()
 
@@ -43,14 +51,17 @@ def run_episode(size: int = 8):
     print_board(board)
 
     done, step = False, 0
-    while not done:
+    while not done and step < max_steps:
         action, reason = agent.select_action_with_reason(env)
         print(f"Step {step}: placing at {action} because {reason}")
         board, reward, done = env.step(action)
         print_board(board)
         step += 1
 
-    print("Game over – no legal moves remain.")
+    if done:
+        print("Game over – no legal moves remain.")
+    else:
+        print(f"Reached step limit of {max_steps}; stopping.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Prevent `play_reasoning.py` from running indefinitely by adding a configurable `max_steps` limit
- Document why the limit is necessary and report when the step cap is reached

## Testing
- `python play_reasoning.py > /tmp/out2`

------
https://chatgpt.com/codex/tasks/task_e_689d453d762c832aa30b190ee60d5bd6